### PR TITLE
feat(vision): 优化视觉检测逻辑并增加配置接口

### DIFF
--- a/main/boards/sensecap-watcher/sscma_camera.h
+++ b/main/boards/sensecap-watcher/sscma_camera.h
@@ -1,6 +1,7 @@
 #ifndef SSCMA_CAMERA_H
 #define SSCMA_CAMERA_H
 
+#include <cstdint>
 #include <lvgl.h>
 #include <thread>
 #include <memory>
@@ -35,7 +36,30 @@ private:
     jpeg_dec_handle_t jpeg_dec_;
     jpeg_dec_io_t *jpeg_io_;
     jpeg_dec_header_info_t *jpeg_out_;
-    int64_t last_detect_tm;
+    // 检测状态机
+    enum DetectionState {
+        IDLE,           // 空闲状态
+        VALIDATING,     // 验证中（连续检测3秒）
+        COOLDOWN        // 冷却期（等待重新检测）
+    };
+    
+    DetectionState detection_state = IDLE;
+    int64_t state_start_time = 0;
+    bool need_start_cooldown = false; // 是否需要开始冷却期
+    int64_t last_detected_time = 0; // 验证期间最后一次检测到物体的时间
+    
+    // 缓存检测配置参数以避免频繁NVS访问
+    int cached_target_type = 0;
+
+    int cached_detect_threshold = 75;
+    int cached_detect_duration_sec = 2; // 检测持续时间2秒，确认人员持续存在
+    int cached_detect_invoke_interval_sec = 8; // 默认15秒冷却期，避免频繁开始会话
+    int cached_detect_debounce_sec = 1; // 验证期间人员离开的去抖动时间1秒
+
+    int64_t cached_detect_duration_us = cached_detect_duration_sec * 1000000LL; // 3秒 = 3,000,000微秒
+    int64_t cached_detect_invoke_interval_us = cached_detect_invoke_interval_sec * 1000000LL; // 1秒 = 1,000,000微秒
+    const int64_t cached_detect_debounce_us = cached_detect_debounce_sec * 1000000LL; // 去抖动时间
+    int64_t last_config_load_tm = 0;
 public:
     SscmaCamera(esp_io_expander_handle_t io_exp_handle);
     ~SscmaCamera();

--- a/main/mcp_server.cc
+++ b/main/mcp_server.cc
@@ -13,6 +13,7 @@
 #include "application.h"
 #include "display.h"
 #include "board.h"
+#include "settings.h"
 
 #define TAG "MCP"
 
@@ -100,6 +101,76 @@ void McpServer::AddCommonTools() {
                 }
                 auto question = properties["question"].value<std::string>();
                 return camera->Explain(question);
+            });
+
+        // 获取人体检测配置
+        AddTool("self.vision.get_detection_config",
+            "Get the current vision detection configuration. Use this tool when user asks about vision settings, detection parameters, or camera configuration. Returns threshold, interval, and target type settings.",
+            PropertyList(),
+            [](const PropertyList& properties) -> ReturnValue {
+                Settings settings("vision", false);
+                int threshold = settings.GetInt("threshold", 75);
+                int interval = settings.GetInt("interval", 8);
+                int duration = settings.GetInt("duration", 2);
+                int target_type = settings.GetInt("target", 0);
+                
+                std::string result = "{\"threshold\":" + std::to_string(threshold) + 
+                                   ",\"interval\":" + std::to_string(interval) + 
+                                   ",\"duration\":" + std::to_string(duration) + 
+                                   ",\"target_type\":" + std::to_string(target_type) + "}";
+                return result;
+            });
+
+        // 设置人体检测配置
+        AddTool("self.vision.set_detection_config",
+            "Set person detection configuration parameters.\n"
+            "Args:\n"
+            "  `threshold`: Detection confidence threshold (0-100, default 75)\n"
+            "  `interval`: Cooldown period after conversation ends, prevents frequent interruptions (default 8 seconds)\n"
+            "  `duration`: Detection duration (default 2 seconds) \n"
+            "  `target_type`: Target type to detect (0=person, 1=body, default 0)",
+            PropertyList({
+                Property("threshold", kPropertyTypeInteger, 75, 0, 100),
+                Property("interval", kPropertyTypeInteger, 8, 1, 60),
+                Property("duration", kPropertyTypeInteger, 2, 1, 60),
+                Property("target_type", kPropertyTypeInteger, 0, 0, 1)
+            }),
+            [](const PropertyList& properties) -> ReturnValue {
+                Settings settings("vision", true);
+                
+                try {
+                    const Property& threshold_prop = properties["threshold"];
+                    int threshold = threshold_prop.value<int>();
+                    settings.SetInt("threshold", threshold);
+                } catch (const std::runtime_error&) {
+                    // threshold parameter not provided, skip
+                }
+                
+                try {
+                    const Property& interval_prop = properties["interval"];
+                    int interval = interval_prop.value<int>();
+                    settings.SetInt("interval", interval);
+                } catch (const std::runtime_error&) {
+                    // interval parameter not provided, skip
+                }
+                
+                try {
+                    const Property& duration_prop = properties["duration"];
+                    int duration = duration_prop.value<int>();
+                    settings.SetInt("duration", duration);
+                } catch (const std::runtime_error&) {
+                    // duration parameter not provided, skip
+                }
+                
+                try {
+                    const Property& target_prop = properties["target_type"];
+                    int target = target_prop.value<int>();
+                    settings.SetInt("target", target);
+                } catch (const std::runtime_error&) {
+                    // target_type parameter not provided, skip
+                }
+
+                return "{\"status\": \"success\", \"message\": \"Detection configuration updated\"}";
             });
     }
 


### PR DESCRIPTION
  **新添加的功能**

   1. 可配置的视觉检测参数:
       * 现在可以通过 MCP (多模态控制协议) 工具来设置和获取视觉检测的参数。
       * 新增了 self.vision.get_detection_config 工具,用于查询当前的检测配置,包括:
           * threshold: 检测置信度阈值。
           * interval: 对话结束后的冷却时间,防止频繁打扰。
           * duration: 确认目标持续存在的检测时长。
           * target_type: 检测目标的类型 (例如,人)。
       * 新增了 self.vision.set_detection_config 工具,允许用户动态修改上述参数。

   2. 优化的视觉检测状态机:
       * 引入了更精细的检测状态管理 (IDLE, VALIDATING, COOLDOWN),使设备在检测到人之后,行为更符合逻辑。
       * 验证机制: 当检测到目标后,会进入 VALIDATING 状态,持续一段时间 (可配置,默认为2秒) 来确认目标是否持续存在,只有确认后才会触发后续行为 (如发起对话)。这避免了因目标快速闪过而产生的误触发。
       * 冷却机制: 在一次成功的触发和对话后,设备会进入 COOLDOWN 状态 (可配置,默认为8秒),在此期间即使检测到目标也不会立即触发,避免了过于频繁的交互。
       * 去抖动机制: 在验证期间,如果目标短暂消失,系统会等待一小段时间 (默认为1秒),确认目标确实离开后才重置状态,增强了稳定性。

**修复的功能**

   * 本次提交主要是功能增强,没有明确的 Bug 修复。其核心是改进了之前较为简单的视觉检测逻辑,使其更加健壮和人性化。

**修改说明**

  为了实现上述功能,主要对以下文件进行了修改:

   1. `main/boards/sensecap-watcher/sscma_camera.cc`:
       * 重构检测逻辑: 完全重写了 sscma_client_callback_t 中的回调函数。
       * 引入状态机: 使用 detection_state (IDLE, VALIDATING, COOLDOWN) 来管理检测流程。
       * 参数缓存: 为了避免频繁从 NVS (非易失性存储) 中读取配置,增加了 cached_* 系列变量,每5秒从 Settings 中更新一次配置参数。
       * 时间戳判断: 大量使用 esp_timer_get_time() 来精确控制验证时长、冷却时间和去抖动时间。

   2. `main/boards/sensecap-watcher/sscma_camera.h`:
       * 添加状态枚举: 定义了 DetectionState 枚举。
       * 声明新成员变量: 添加了用于状态机管理 (detection_state, state_start_time 等) 和参数缓存 (cached_target_type, cached_detect_threshold 等) 的成员变量。

   3. `main/mcp_server.cc`:
       * 添加新工具: 在 AddCommonTools 函数中,使用 AddTool 方法注册了 self.vision.get_detection_config 和 self.vision.set_detection_config 两个新的工具。
       * 实现工具逻辑:
           * get_detection_config 的实现逻辑是从 Settings 类中读取 "vision" 相关的配置项并以 JSON 格式返回。
           * set_detection_config 的实现逻辑是解析传入的参数,并使用 Settings 类将新值写入 NVS。